### PR TITLE
Added Cadence xcelium to tb/core/Makefile and fixed task_write() issue#2

### DIFF
--- a/tb/core/.gitignore
+++ b/tb/core/.gitignore
@@ -14,3 +14,4 @@ csrc
 inter.vpd
 ucli.key
 vc_hdrs.h
+fpnew/

--- a/tb/core/Makefile
+++ b/tb/core/Makefile
@@ -53,6 +53,10 @@ DSIM_HOME               = /tools/Metrics/dsim
 DSIM_FLAGS              = -timescale 1ns/1ps
 DSIM_IMAGE		= dsim.out
 
+# xrun is the Cadence xcelium utility to ruun simulations (https://cadence.com/)
+XRUN                    = xrun
+XRUN_FLAGS              = -clean -smartorder -sv -top worklib.tb_top -timescale 1ns/1ps
+XRUN_DIR                = xcelium.d
 # verilator configuration
 VERILATOR		= verilator
 VERI_FLAGS              +=
@@ -204,6 +208,31 @@ dsim-clean:
 
 dsim-clean-all: dsim-clean
 	rm -rf fpnew
+# xrun testbench compilation
+.PHONY: xrun-all
+xrun-all: $(RTLSRC_PKG) $(RTLSRC) $(RTLSRC_TB_PKG) $(RTLSRC_TB)
+	$(XRUN) \
+		$(XRUN_FLAGS) \
+		$(RTLSRC_PKG) $(RTLSRC) $(RTLSRC_TB_PKG) $(RTLSRC_TB) \
+		+incdir+$(RTLSRC_INCDIR)
+.PHONY: xrun-hello_world xrun-firmware
+xrun-hello_world: xrun-all custom/hello_world.hex
+	$(XRUN) \
+		$(XRUN_FLAGS) \
+		$(RTLSRC_PKG) $(RTLSRC) $(RTLSRC_TB_PKG) $(RTLSRC_TB) \
+		+incdir+$(RTLSRC_INCDIR) +firmware=custom/hello_world.hex
+xrun-firmware: xrun-all firmware/firmware.hex
+	$(XRUN) \
+		$(XRUN_FLAGS) \
+		$(RTLSRC_PKG) $(RTLSRC) $(RTLSRC_TB_PKG) $(RTLSRC_TB) \
+		+incdir+$(RTLSRC_INCDIR) +firmware=firmware/firmware.hex
+# xrun cleanup
+.PHONY: xrun-clean xrun-clean-all
+xrun-clean:
+	rm -vrf $(XRUN_DIR)
+xrun-clean-all: xrun-clean
+	rm -vrf $(addprefix firmware/firmware., elf bin hex map) \
+		$(FIRMWARE_OBJS) $(FIRMWARE_TEST_OBJS) $(COMPLIANCE_TEST_OBJS)
 
 # verilator testbench compilation
 

--- a/tb/core/dp_ram.sv
+++ b/tb/core/dp_ram.sv
@@ -73,7 +73,7 @@ module dp_ram
         read_byte = mem[byte_addr];
     endfunction
 
-    task write_byte(input integer byte_addr, logic [7:0] val, output logic [7:0] other);
+    task write_byte(input logic [ADDR_WIDTH-1:0] byte_addr, logic [7:0] val, output logic [7:0] other);
         mem[byte_addr] = val;
         other          = mem[byte_addr];
 


### PR DESCRIPTION
Fir pull request, adding support for Cadence xcelium simulator. Also, fixing [issue#2](https://github.com/MikeOpenHWGroup/riscv-experimental/issues/2) in tb/core/dp_ram.sv

custom/helloworld.hex and firmware/firmware.hex targets simulated successfully 